### PR TITLE
fix - regexp for plugins - tinymce по-умолчанию вставляет атрибут alt=""

### DIFF
--- a/cms/mod_admin/admin.func.php
+++ b/cms/mod_admin/admin.func.php
@@ -783,7 +783,7 @@ function admin_save_data($params)
 		
 		$options_field=array();
 		foreach($params as $key=>$value) {
-			if(preg_match('/\<img\ssrc=\"\/cms\/external\/tiny_mce\/plugins\/mymodules\/module\.php\?[\@\-\_0-9a-z\=A-Z\&]+\"\s\/\>/',$value)){
+			if(preg_match('/\<img\ssrc=\"\/cms\/external\/tiny_mce\/plugins\/mymodules\/module\.php\?[\@\-\_0-9a-z\=A-Z\&]+\".[^\>]*\>/',$value)){
 				$options_field[$key]=1;
 			}
 		}

--- a/cms/mod_orm/orm.func.php
+++ b/cms/mod_orm/orm.func.php
@@ -1613,7 +1613,7 @@ abstract class ActiveRecord implements ArrayAccess, Iterator, Countable //extend
 					
 					if(isset($admin_options[$name])){
 						return preg_replace_callback(
-							'/\<img\ssrc=\"\/cms\/external\/tiny_mce\/plugins\/mymodules\/module\.php\?([\@\-\_0-9a-zA-Z\&]+)\=([\-\_0-9a-zA-Z\&]+)\"\s\/\>/',
+							'/\<img\ssrc=\"\/cms\/external\/tiny_mce\/plugins\/mymodules\/module\.php\?([\@\-\_0-9a-zA-Z\&]+)\=([\-\_0-9a-zA-Z\&]+)\".[^\>]*\>/',
 							create_function(
 								 
 								'$matches',


### PR DESCRIPTION
Tinymce 4 автоматически добавляет к картинкам атрибут alt="", от этого регулярка не проходит. да и гибче она так становится
