### PR TITLE
исправление функции preview

### DIFF
--- a/cms/mod_helpers/helpers.func.php
+++ b/cms/mod_helpers/helpers.func.php
@@ -460,8 +460,8 @@ function path_to($params)
 
 function preview($adress,$param1=false,$param2=false )
 {	
-	$orig_params = $adress;
 	if(is_array($adress)){
+		$orig_params = $adress;
 		if(isset($adress['height']) || isset($adress[2])){
 			if(isset($adress['width'])){
 				$width=$adress['width'];
@@ -491,6 +491,7 @@ function preview($adress,$param1=false,$param2=false )
 		}
 		//Массив значений
 	}else{
+		$orig_params = array();
 		if($param2===false){
 			//обычная превью
 			$num=1;


### PR DESCRIPTION
Функция preview поддерживает возможность передавать аргументы не в виде массива, а списком: preview($image, $width, $height). При таком вызове некорректно работали дополнительные параметры.