### PR TITLE
исправление save

### DIFF
--- a/cms/mod_orm/orm.func.php
+++ b/cms/mod_orm/orm.func.php
@@ -1167,7 +1167,7 @@ abstract class ActiveRecord implements ArrayAccess, Iterator, Countable //extend
 				foreach($this->_future_data as $key => $value) {
 					$fields[]=" ".DB_FIELD_DEL . $key . DB_FIELD_DEL." ";
 					
-					if(SQL_NULL === $value || (substr($key,-3)=='_id' && $value==='')){
+					if(SQL_NULL === $value || (substr($key,-3)=='_id' && !$value && $value !== '0' && $value !== 0)){
 						$values[]=" NULL ";
 					}else{
 						$values[]=" ". doitClass::$instance->db->quote ($value)." ";
@@ -1192,7 +1192,7 @@ abstract class ActiveRecord implements ArrayAccess, Iterator, Countable //extend
 				$attributes=array();
 				foreach($this->_future_data as $key => $value) {
 
-					if(SQL_NULL === $value  || (substr($key,-3)=='_id' && $value==='')){
+					if(SQL_NULL === $value  || (substr($key,-3)=='_id' && !$value && $value !== '0' && $value !== 0)){
 						$attributes[]=" ". DB_FIELD_DEL . $key. DB_FIELD_DEL ." = NULL ";
 					}else{
 						$attributes[]=" ". DB_FIELD_DEL . $key. DB_FIELD_DEL ." = ". doitClass::$instance->db->quote($value)." ";


### PR DESCRIPTION
В некоторых версиях mysql метод save вызывал ошибку если присвоить полю *_id значение null. Ошибку вызывала попытка записать пустую строку в поле типа integer.